### PR TITLE
Syntax Highlighting

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -10,6 +10,9 @@
 
 \input{ads/header}
 
+% Include extensions
+\input{settings/extensions}
+
 \input{content/glossary}
 
 \begin{document}

--- a/settings/extensions.tex
+++ b/settings/extensions.tex
@@ -1,27 +1,31 @@
 %!TEX root = ../main.tex
 
 % Define syntax highlighting for yaml files
-\newcommand\YAMLcolonstyle{\color{red}\mdseries}
-\newcommand\YAMLkeystyle{\color{black}\bfseries}
-\newcommand\YAMLvaluestyle{\color{blue}\mdseries}
+\newcommand\colonstyle{\color{red}\mdseries}
+\newcommand\keystyle{\color{black}\bfseries}
+\newcommand\valuestyle{\color{blue}\mdseries}
 
+% The following block defines new languages
 \makeatletter
 
-% here is a macro expanding to the name of the language
-% (handy if you decide to change it further down the road)
-\newcommand\language@yaml{yaml}
+% for yaml files.
+\newcommand\ProcessThreeDashes{\llap{\color{cyan}\mdseries-{-}-}}
 
+% Define highlighting for yaml
+\newcommand\language@yaml{yaml}
 \expandafter\expandafter\expandafter\lstdefinelanguage
 \expandafter{\language@yaml}
 {
     keywords={true,false,null,y,n},
-    keywordstyle=\color{darkgray}\bfseries,
+    keywordstyle=\color{keywordcolor},
+    commentstyle=\color{commentcolor},
+    stringstyle=\color{stringcolor},
     sensitive=false,
     comment=[l]{\#},
     morecomment=[s]{/*}{*/},
     moredelim=[l][\color{orange}]{\&},
     moredelim=[l][\color{magenta}]{*},
-    moredelim=**[il][\YAMLcolonstyle{:}\YAMLvaluestyle]{:},   % switch to value style at :
+    moredelim=**[il][\colonstyle{:}\valuestyle]{:},   % switch to value style at :
     morestring=[b]',
     morestring=[b]",
     literate =    {---}{{\ProcessThreeDashes}}3
@@ -29,9 +33,23 @@
                 {|}{{\textcolor{red}\textbar}}1 
                 {\ -\ }{{\mdseries\ -\ }}3,
 }
+\lst@AddToHook{EveryLine}{\ifx\lst@language\language@yaml\keystyle\fi}
+
+% Define highlighting for dockerfiles
+\newcommand\language@docker{docker}
+\expandafter\expandafter\expandafter\lstdefinelanguage
+\expandafter{\language@docker}
+{
+    keywords={FROM, RUN, CMD, LABEL, MAINTAINER, EXPOSE, ENV, ADD, COPY, ENTRYPOINT, VOLUME, USER, WORKDIR, ARG, ONBUILD, STOPSIGNAL, HEALTHCHECK, SHELL, User},
+    keywordstyle=\color{keywordcolor},
+    commentstyle=\color{commentcolor},
+    stringstyle=\color{stringcolor},
+    sensitive=true,
+    comment=[l]{\#},
+    morestring=[b]',
+    morestring=[b]"
+}
 
 % switch to key style at EOL
-\lst@AddToHook{EveryLine}{\ifx\lst@language\language@yaml\YAMLkeystyle\fi}
+\lst@AddToHook{EveryLine}{\ifx\lst@language\language@docker\keystyle\fi}
 \makeatother
-
-\newcommand\ProcessThreeDashes{\llap{\color{cyan}\mdseries-{-}-}}

--- a/settings/extensions.tex
+++ b/settings/extensions.tex
@@ -1,0 +1,37 @@
+%!TEX root = ../main.tex
+
+% Define syntax highlighting for yaml files
+\newcommand\YAMLcolonstyle{\color{red}\mdseries}
+\newcommand\YAMLkeystyle{\color{black}\bfseries}
+\newcommand\YAMLvaluestyle{\color{blue}\mdseries}
+
+\makeatletter
+
+% here is a macro expanding to the name of the language
+% (handy if you decide to change it further down the road)
+\newcommand\language@yaml{yaml}
+
+\expandafter\expandafter\expandafter\lstdefinelanguage
+\expandafter{\language@yaml}
+{
+    keywords={true,false,null,y,n},
+    keywordstyle=\color{darkgray}\bfseries,
+    sensitive=false,
+    comment=[l]{\#},
+    morecomment=[s]{/*}{*/},
+    moredelim=[l][\color{orange}]{\&},
+    moredelim=[l][\color{magenta}]{*},
+    moredelim=**[il][\YAMLcolonstyle{:}\YAMLvaluestyle]{:},   % switch to value style at :
+    morestring=[b]',
+    morestring=[b]",
+    literate =    {---}{{\ProcessThreeDashes}}3
+                {>}{{\textcolor{red}\textgreater}}1     
+                {|}{{\textcolor{red}\textbar}}1 
+                {\ -\ }{{\mdseries\ -\ }}3,
+}
+
+% switch to key style at EOL
+\lst@AddToHook{EveryLine}{\ifx\lst@language\language@yaml\YAMLkeystyle\fi}
+\makeatother
+
+\newcommand\ProcessThreeDashes{\llap{\color{cyan}\mdseries-{-}-}}

--- a/settings/main.tex
+++ b/settings/main.tex
@@ -31,8 +31,6 @@
 	\definecolor{stringcolor}{rgb}{0.627,0.126,0.941}
 }
 
-
-
 %% Syntax Highlighting (Listings)
 \newcommand{\listingsettings}{%
 	\lstset{%
@@ -46,8 +44,8 @@
 		postbreak=\space,		% break line after space
 		tabsize=2,				% tabulator size
 		basicstyle=\ttfamily\footnotesize, % font style
-		showstringspaces=false,	% Show spaces in strings
-		showspaces=false,		% show space (true, false)		showstringspaces=false,	% show space in strings (true, false)
+		showspaces=false,		% show space (true, false)		
+		showstringspaces=false,	% show space in strings (true, false)
 		extendedchars=true,		% show all Latin1 characters (true, false)
 		captionpos=b,			% sets the caption-position to bottom
 		backgroundcolor=\color{ListingBackground}, % source code background

--- a/settings/main.tex
+++ b/settings/main.tex
@@ -26,7 +26,12 @@
 \newcommand{\defineColors}{%
 	\definecolor{LinkColor}{HTML}{\linkColor}
 	\definecolor{ListingBackground}{HTML}{F8F8F8}
+	\definecolor{keywordcolor}{rgb}{0.133,0.133,0.6}
+	\definecolor{commentcolor}{rgb}{0.133,0.545,0.133}
+	\definecolor{stringcolor}{rgb}{0.627,0.126,0.941}
 }
+
+
 
 %% Syntax Highlighting (Listings)
 \newcommand{\listingsettings}{%
@@ -41,6 +46,7 @@
 		postbreak=\space,		% break line after space
 		tabsize=2,				% tabulator size
 		basicstyle=\ttfamily\footnotesize, % font style
+		showstringspaces=false,	% Show spaces in strings
 		showspaces=false,		% show space (true, false)		showstringspaces=false,	% show space in strings (true, false)
 		extendedchars=true,		% show all Latin1 characters (true, false)
 		captionpos=b,			% sets the caption-position to bottom
@@ -52,8 +58,8 @@
 		rulecolor=\color{darkgray},	% border color
 		fillcolor=\color{ListingBackground},
 		aboveskip=20pt,
-		keywordstyle=\color[rgb]{0.133,0.133,0.6},
-		commentstyle=\color[rgb]{0.133,0.545,0.133},
-		stringstyle=\color[rgb]{0.627,0.126,0.941}
+		keywordstyle=\color{keywordcolor},
+		commentstyle=\color{commentcolor},
+		stringstyle=\color{stringcolor}
 	}
 }


### PR DESCRIPTION
Hinzugefügt wurde syntax highlightung für yaml und dockerfiles. 
Weitere Sprachen welche bisher nicht von Latex nativ unterstützt werden lassen sich einfacher hinzufügen.